### PR TITLE
fix: not notifying for pre-scheduled announcements

### DIFF
--- a/classes/HaloWatcher.js
+++ b/classes/HaloWatcher.js
@@ -138,7 +138,7 @@ export class HaloWatcher extends EventEmitter {
 				const isRecentAnnouncement = function (announcement) {
 					const publishTime = new Date(announcement.publishDate).getTime();
 					const startTime = new Date(announcement.startDate).getTime();
-					const threshold = new Date().getTime() - 1000 * 60 * 60 * 6; // 6 hours
+					const threshold = new Date().getTime() - 1000 * 60 * 60 * 48; // 48 hours
 
 					return publishTime > threshold || startTime > threshold;
 				};

--- a/classes/HaloWatcher.js
+++ b/classes/HaloWatcher.js
@@ -131,10 +131,21 @@ export class HaloWatcher extends EventEmitter {
 				//write local cache to file, since changes were detected
 				await writeCacheFile({ filepath: class_id, data: new_announcements });
 
+				/**
+				 * Determine if an announcement was published "recently" (determined by inner-function criteria)
+				 * @returns {boolean} Whether or not the announcement was published recently
+				 */
+				const isRecentAnnouncement = function (announcement) {
+					const publishTime = new Date(announcement.publishDate).getTime();
+					const startTime = new Date(announcement.startDate).getTime();
+					const threshold = new Date().getTime() - 1000 * 60 * 60 * 6; // 6 hours
+
+					return publishTime > threshold || startTime > threshold;
+				};
+
 				// to prevent announcement spam upon bot restart, only emit announcements that were published in past 6 hours
 				for (const announcement of this.#locateDifferenceInArrays(new_announcements, old_announcements))
-					new Date(announcement.publishDate).getTime() > new Date().getTime() - 1000 * 60 * 60 * 6 &&
-						this.emit('announcement', announcement);
+					isRecentAnnouncement(announcement) && this.emit('announcement', announcement);
 			} catch (e) {
 				if (e.code === 401)
 					Logger.unauth(`Received 401 while fetching announcements for course ${course.courseCode}`);

--- a/classes/services/HaloService.js
+++ b/classes/services/HaloService.js
@@ -91,6 +91,7 @@ export const getClassAnnouncements = async function ({ cookie, class_id, metadat
 						id
 						content
 						publishDate
+						startDate
 						title
 						postStatus
 						createdBy {


### PR DESCRIPTION
- Incorporates the `startDate` field of an announcement object for announcements which are scheduled several hours beforehand by professors
- Also raises the threshold from 6h to 48h
	- This is in attempt to mitigate announcements that were not sent after an overnight outage